### PR TITLE
Additional standard #include files for src/gdb.c

### DIFF
--- a/src/gdb.c
+++ b/src/gdb.c
@@ -6,6 +6,8 @@
 #include <sys/ptrace.h>
 #include <sys/wait.h>
 #include <signal.h>
+#include <stdlib.h>
+#include <stdio.h>
 
 void seg() {
     raise(SIGSEGV);


### PR DESCRIPTION
This is required to avoid build failures with future compilers which do not support implicit function declarations (such as exit and perror in this file).

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC
